### PR TITLE
Apply proxy if provided

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.6-alpine3.6
 
+ARG https_proxy_url
+
+ENV HTTP_PROXY "$https_proxy_url"
+ENV HTTPS_PROXY "$https_proxy_url"
+
 COPY app.py /opt/stix/app.py
 COPY gunicorn_config.py /opt/stix/gunicorn_config.py
 #ADD ./ /root/


### PR DESCRIPTION
Supports unfetter-discover/unfetter#1538

This assumes the proxy is supplied as a `buildarg` to the build for this Docker image.  Testing of this PR should be done within the confines of the PR referenced above.